### PR TITLE
Use old npm module structure

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ function install_jdk
 
 function install_appium
 {
-    npm install appium@$APPIUM_VERSION
+    npm install --legacy-bundling appium@$APPIUM_VERSION
     mkdir -p /root/appium/appium/
     mv /root/node_modules/appium $appium_directory
     mkdir $appium_directory/build/SafariLauncher


### PR DESCRIPTION
With npm 3, npm has flattened the node_modules directory. This breaks
the way that we move the appium directory out of the node_modules
directory: the dependencies are no longer moved as well.

We can resolve the issue by using the old directory structure.